### PR TITLE
"Server doesn't allow e-mail address verification"

### DIFF
--- a/contact.sh
+++ b/contact.sh
@@ -106,9 +106,11 @@ domain() {
 
     # RFC 2142 (security@)
     printf "${GREEN}[+]${END} Doing an RFC 2142 check (security@$1) \n | Confidence level: ${YELLOW}★ ★ ☆${END} \n"
-    SECURITYAT=$(curl --max-time 9 -X POST --silent https://mailtester.com/testmail.php -d "email=security@$OPTARG" | grep "E-mail address is valid")
-    if [ ${#SECURITYAT} -gt 0 ]; then
-        echo "security@$1 is valid!"
+    SECURITYAT=$(curl --max-time 9 -X POST --silent https://mailtester.com/testmail.php -d "email=security@$OPTARG")
+    if [[ $(echo "$SECURITYAT" | grep "E-mail address is valid") ]]; then
+        printf "security@$1 ${GREEN}is valid!${END}\n"
+    elif [[ $(echo "$SECURITYAT" | grep "Server doesn't allow e-mail address verification") ]]; then
+        echo "Server doesn't allow e-mail address verification."
     else
         printf "security@$1 is ${RED}not${END} valid.\n"
     fi

--- a/contact.sh
+++ b/contact.sh
@@ -110,7 +110,7 @@ domain() {
     if [[ $(echo "$SECURITYAT" | grep "E-mail address is valid") ]]; then
         printf "security@$1 ${GREEN}is valid!${END}\n"
     elif [[ $(echo "$SECURITYAT" | grep "Server doesn't allow e-mail address verification") ]]; then
-        echo "Server doesn't allow e-mail address verification."
+        printf "${RED}Error:${END} Server doesn't allow e-mail address verification.\n"
     else
         printf "security@$1 is ${RED}not${END} valid.\n"
     fi


### PR DESCRIPTION
I couldn't test this in batch, since there's a very strict rate limiting in place, but "Server doesn't allow e-mail address verification" is a very common output of mailtester.com.

In this case, I think it's better to print this message instead of "security@company.com is not valid.", which may not be true.